### PR TITLE
Don't enable "-Werror" per default

### DIFF
--- a/modules/configure.cc
+++ b/modules/configure.cc
@@ -166,3 +166,4 @@ mkl_option "Compiler" "env:PKG_CONFIG_PATH" "--pkg-config-path" "Extra paths for
 mkl_option "Compiler" "WITH_PROFILING" "--enable-profiling" "Enable profiling"
 mkl_option "Compiler" "WITH_STATIC_LINKING" "--enable-static" "Enable static linking"
 mkl_option "Compiler" "WITHOUT_OPTIMIZATION" "--disable-optimization" "Disable optimization flag to compiler" "n"
+mkl_option "Compiler" "env:MKL_WANT_WERROR" "--enable-werror" "Enable compiler warnings as errors" "n"

--- a/modules/configure.good_cflags
+++ b/modules/configure.good_cflags
@@ -9,5 +9,10 @@
 
 function checks {
     mkl_mkvar_append CPPFLAGS CPPFLAGS \
-        "-Wall -Werror -Wfloat-equal -Wpointer-arith"
+        "-Wall -Wfloat-equal -Wpointer-arith"
+
+    if [[ $MKL_WANT_WERROR = "y" ]]; then
+        mkl_mkvar_append CPPFLAGS CPPFLAGS \
+            "-Werror"
+    fi
 }


### PR DESCRIPTION
Things are going to change. Warnings will be added, new compiler may become stricter
and considers a particular piece of code as something to warn about is not going to
change the quality of the software per-se; and while it’s true that fixing the
warnings early can save from failing further down the road, users often enough just
need the thing to build and work when they need it, and would prefer not to have to
fix a few warnings first.

So using `-Werror` per default on released code is not a good default.

This commit will make `-Werror` optional and disabled per default. Developers can
still pass `--enable-werror` option to configure to build with this flag during
development.