### PR TITLE
Move libs to last compiler parameter in mkl_compile_check

### DIFF
--- a/modules/configure.base
+++ b/modules/configure.base
@@ -940,7 +940,7 @@ function mkl_compile_check {
 int main () { return 0; }
 " >> $srcfile
 
-    local cmd="${!4} $cflags $(mkl_mkvar_get CPPFLAGS) -Wall -Werror $5 $srcfile -o ${srcfile}.o $ldf $(mkl_mkvar_get LDFLAGS)";
+    local cmd="${!4} $cflags $(mkl_mkvar_get CPPFLAGS) -Wall -Werror $srcfile -o ${srcfile}.o $ldf $(mkl_mkvar_get LDFLAGS) $5";
     mkl_dbg "Compile check $1 ($2): $cmd"
 
     local output


### PR DESCRIPTION
Linker did not find static lib functions in provided test source code snippet
in previous way